### PR TITLE
Implement u31_ext multiply by u31

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+bitvm = { git = "https://github.com/BitVM/BitVM" }
 bitcoin-script = { git = "https://github.com/BitVM/rust-bitcoin-script" }
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin", branch = "bitvm" }
 bitcoin-scriptexec = { git = "https://github.com/BitVM/rust-bitcoin-scriptexec/" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,13 @@
-use bitcoin::{hashes::Hash, TapLeafHash, Transaction};
-use bitcoin_script::define_pushable;
-use bitcoin_scriptexec::{Exec, ExecCtx, ExecutionResult, Options, TxTemplate};
-
 mod u31;
 pub use u31::*;
 
 mod u31_ext;
 pub use u31_ext::*;
 
-define_pushable!();
-
 pub fn unroll<F, T>(count: u32, mut closure: F) -> Vec<T>
 where
     F: FnMut(u32) -> T,
-    T: pushable::Pushable,
+    T: bitvm::treepp::pushable::Pushable,
 {
     let mut result = vec![];
 
@@ -21,33 +15,4 @@ where
         result.push(closure(i))
     }
     result
-}
-
-pub fn execute_script(script: bitcoin::ScriptBuf) -> ExecutionResult {
-    let mut exec = Exec::new(
-        ExecCtx::Tapscript,
-        Options::default(),
-        TxTemplate {
-            tx: Transaction {
-                version: bitcoin::transaction::Version::TWO,
-                lock_time: bitcoin::locktime::absolute::LockTime::ZERO,
-                input: vec![],
-                output: vec![],
-            },
-            prevouts: vec![],
-            input_idx: 0,
-            taproot_annex_scriptleaf: Some((TapLeafHash::all_zeros(), None)),
-        },
-        script,
-        vec![],
-    )
-    .expect("error creating exec");
-
-    loop {
-        if exec.exec_next().is_err() {
-            break;
-        }
-    }
-    let res = exec.result().unwrap();
-    res.clone()
 }

--- a/src/u31/mod.rs
+++ b/src/u31/mod.rs
@@ -1,11 +1,10 @@
-use crate::{pushable, unroll};
-use bitcoin::ScriptBuf as Script;
-use bitcoin_script::script;
+use bitvm::treepp::*;
 
 mod m31;
 pub use m31::*;
 
 mod babybear;
+use crate::unroll;
 pub use babybear::*;
 
 pub trait U31Config {
@@ -171,7 +170,7 @@ pub fn u31_mul<M: U31Config>() -> Script {
 
 #[cfg(test)]
 mod test {
-    use crate::execute_script;
+    use bitvm::treepp::*;
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 

--- a/src/u31/mod.rs
+++ b/src/u31/mod.rs
@@ -12,26 +12,26 @@ pub trait U31Config {
     const MOD: u32;
 }
 
-fn u31_to_v31<M: U31Config>() -> Script {
+pub fn u31_to_v31<M: U31Config>() -> Script {
     script! {
         { M::MOD } OP_SUB
     }
 }
 
-fn v31_to_u31<M: U31Config>() -> Script {
+pub fn v31_to_u31<M: U31Config>() -> Script {
     script! {
         { M::MOD } OP_ADD
     }
 }
 
-fn u31_add_v31<M: U31Config>() -> Script {
+pub fn u31_add_v31<M: U31Config>() -> Script {
     script! {
         OP_ADD
         { u31_adjust::<M>() }
     }
 }
 
-fn v31_add_u31<M: U31Config>() -> Script {
+pub fn v31_add_u31<M: U31Config>() -> Script {
     script! {
         OP_ADD
         { v31_adjust::<M>() }

--- a/src/u31_ext/babybear.rs
+++ b/src/u31_ext/babybear.rs
@@ -1,8 +1,7 @@
+use crate::karatsuba_big;
 use crate::u31::{u31_add, u31_double, BabyBear};
 use crate::U31ExtConfig;
-use crate::{karatsuba_big, pushable};
-use bitcoin::ScriptBuf as Script;
-use bitcoin_script::script;
+use bitvm::treepp::*;
 
 pub struct BabyBear4;
 
@@ -50,9 +49,8 @@ impl U31ExtConfig for BabyBear4 {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        execute_script, u31ext_add, u31ext_double, u31ext_equalverify, u31ext_mul, u31ext_sub,
-    };
+    use crate::{u31ext_add, u31ext_double, u31ext_equalverify, u31ext_mul, u31ext_sub};
+    use bitvm::treepp::*;
     use core::ops::{Add, Mul, Neg};
     use p3_field::{AbstractExtensionField, AbstractField, PrimeField32};
     use rand::{Rng, SeedableRng};

--- a/src/u31_ext/karatsuba.rs
+++ b/src/u31_ext/karatsuba.rs
@@ -1,7 +1,5 @@
-use crate::pushable;
 use crate::{u31_add, u31_mul, u31_sub, U31Config};
-use bitcoin::ScriptBuf as Script;
-use bitcoin_script::script;
+use bitvm::treepp::*;
 
 // Input: A1 B1 A2 B2
 // Output:
@@ -99,9 +97,9 @@ pub fn karatsuba_big<M: U31Config>() -> Script {
 
 #[cfg(test)]
 mod test {
-    use crate::{execute_script, karatsuba_small, BabyBear};
-    use crate::{karatsuba_big, pushable};
-    use bitcoin_script::script;
+    use crate::karatsuba_big;
+    use crate::{karatsuba_small, BabyBear};
+    use bitvm::treepp::*;
     use core::ops::{Add, Mul};
     use p3_baby_bear::BabyBear as P3BabyBear;
     use p3_field::PrimeField32;

--- a/src/u31_ext/karatsuba_complex.rs
+++ b/src/u31_ext/karatsuba_complex.rs
@@ -1,7 +1,5 @@
-use crate::pushable;
 use crate::{u31_add, u31_mul, u31_sub, U31Config};
-use bitcoin::ScriptBuf as Script;
-use bitcoin_script::script;
+use bitvm::treepp::*;
 
 // Input: A1 B1 A2 B2
 // Output:
@@ -91,9 +89,9 @@ pub fn karatsuba_complex_big<M: U31Config>() -> Script {
 
 #[cfg(test)]
 mod test {
-    use crate::{execute_script, M31};
-    use crate::{karatsuba_complex_big, karatsuba_complex_small, pushable};
-    use bitcoin_script::script;
+    use crate::M31;
+    use crate::{karatsuba_complex_big, karatsuba_complex_small};
+    use bitvm::treepp::*;
     use core::ops::{Add, Mul, Sub};
     use p3_field::extension::Complex;
     use p3_field::PrimeField32;

--- a/src/u31_ext/m31.rs
+++ b/src/u31_ext/m31.rs
@@ -1,7 +1,5 @@
-use crate::pushable;
 use crate::{karatsuba_complex_big, u31_add, u31_double, u31_sub, U31ExtConfig, M31};
-use bitcoin::ScriptBuf as Script;
-use bitcoin_script::script;
+use bitvm::treepp::*;
 
 pub struct QM31;
 
@@ -35,9 +33,8 @@ impl U31ExtConfig for QM31 {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        execute_script, u31ext_add, u31ext_double, u31ext_equalverify, u31ext_mul, u31ext_sub,
-    };
+    use crate::{u31ext_add, u31ext_double, u31ext_equalverify, u31ext_mul, u31ext_sub};
+    use bitvm::treepp::*;
     use core::ops::{Add, Mul, Neg};
     use p3_field::extension::Complex;
     use p3_field::{AbstractExtensionField, AbstractField, PrimeField32};

--- a/src/u31_ext/mod.rs
+++ b/src/u31_ext/mod.rs
@@ -1,4 +1,3 @@
-use bitcoin::opcodes::Ordinary::OP_TOALTSTACK;
 use crate::{u31_add_v31, u31_to_bits, u31_to_v31, unroll, v31_add, v31_double};
 use bitvm::treepp::*;
 
@@ -178,10 +177,10 @@ pub fn u31ext_mul_u31<C: U31ExtConfig>() -> Script {
 
 #[cfg(test)]
 mod test {
-    use crate::{u31ext_equalverify, u31ext_mul_u31, QM31, M31, U31Config};
+    use crate::{u31ext_equalverify, u31ext_mul_u31, QM31};
     use bitvm::treepp::*;
     use p3_field::extension::Complex;
-    use p3_field::{AbstractExtensionField, AbstractField, Field, PrimeField32};
+    use p3_field::{AbstractExtensionField, AbstractField, PrimeField32};
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
@@ -213,23 +212,15 @@ mod test {
             { a[0].real().as_canonical_u32() }
             { b.as_canonical_u32() }
             { mul_script.clone() }
-            /*for i in 0..15 {
-                { b.mul_2exp_u64(2 * i).as_canonical_u32() as i64 - (M31::MOD as i64) }
-                { b.mul_2exp_u64(2 * i + 1).as_canonical_u32() as i64 - (M31::MOD as i64) }
-                { (b.mul_2exp_u64(2 * i).as_canonical_u32() + b.mul_2exp_u64(2 * i + 1).as_canonical_u32()) as i64 - (M31::MOD as i64) }
-            }
-            { b.mul_2exp_u64(30).as_canonical_u32() as i64 - (M31::MOD as i64) }*/
             { c[1].imag().as_canonical_u32() }
             { c[1].real().as_canonical_u32() }
             { c[0].imag().as_canonical_u32() }
             { c[0].real().as_canonical_u32() }
-            /*{ u31ext_equalverify::<QM31>() }
-            OP_TRUE*/
+            { u31ext_equalverify::<QM31>() }
+            OP_TRUE
         };
 
         let exec_result = execute_script(script);
-        println!("{:4}", exec_result.final_stack);
-        println!("{:?}", exec_result.error);
         assert!(exec_result.success);
     }
 }

--- a/src/u31_ext/mod.rs
+++ b/src/u31_ext/mod.rs
@@ -1,7 +1,5 @@
-use bitcoin::opcodes::Ordinary::{OP_FROMALTSTACK, OP_ROLL, OP_TOALTSTACK};
-use crate::{pushable, u31_add_v31, u31_to_bits, u31_to_v31, unroll};
-use bitcoin::ScriptBuf as Script;
-use bitcoin_script::script;
+use crate::{u31_add_v31, u31_to_bits, u31_to_v31, unroll, v31_double};
+use bitvm::treepp::*;
 
 mod babybear;
 pub use babybear::*;
@@ -84,54 +82,56 @@ pub fn u31ext_mul_u31<C: U31ExtConfig>() -> Script {
     // input stack:
     //
     // u31ext
-    // a, b, c, d
+    // d, c, b, a
     //
     // u31
     // e
 
     script! {
+        // push a, b to altstack
+        OP_SWAP OP_TOALTSTACK OP_SWAP OP_TOALTSTACK
+
         // push d, c to altstack
-        OP_ROT OP_TOALTSTACK OP_TOALTSTACK
+        OP_SWAP OP_TOALTSTACK OP_SWAP OP_TOALTSTACK
 
-        // push b, a to altstack
-        OP_ROT OP_TOALTSTACK OP_TOALTSTACK
+        { u31_to_v31::<C::BaseFieldConfig>() }
 
-        // create a precomputed table (29 times)
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
+        // create a precomputed table (30 times)
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
 
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
 
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
 
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
 
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
 
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
-        OP_DUP { u31_double() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
+        OP_DUP { v31_double::<C::BaseFieldConfig>() }
 
         // now the stack looks like:
         //    2^0 e
@@ -150,16 +150,16 @@ pub fn u31ext_mul_u31<C: U31ExtConfig>() -> Script {
                 OP_TOALTSTACK
             }
 
-            { 4 + 30 }
+            { 4 }
 
             for _ in 0..31 {
                 OP_FROMALTSTACK
                 OP_IF
                     OP_DUP OP_TOALTSTACK OP_PICK
-                    { u31_add_v31() }
+                    { u31_add_v31::<C::BaseFieldConfig>() }
                     OP_FROMALTSTACK
                 OP_ENDIF
-                OP_1SUB
+                OP_1ADD
             }
 
             OP_DROP
@@ -176,19 +176,57 @@ pub fn u31ext_mul_u31<C: U31ExtConfig>() -> Script {
         OP_DROP
 
         OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK OP_FROMALTSTACK
-
-        OP_SWAP OP_2SWAP OP_SWAP
     }
 }
 
 #[cfg(test)]
 mod test {
+    use crate::{u31ext_equalverify, u31ext_mul_u31, QM31};
+    use bitvm::treepp::*;
     use p3_field::extension::Complex;
+    use p3_field::{AbstractExtensionField, AbstractField, PrimeField32};
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
 
     type F4 = p3_field::extension::BinomialExtensionField<Complex<p3_mersenne_31::Mersenne31>, 2>;
     type F = p3_mersenne_31::Mersenne31;
 
     #[test]
     fn test_u31ext_mul_u31() {
+        let mul_script = u31ext_mul_u31::<QM31>();
+
+        let mut rng = ChaCha20Rng::seed_from_u64(0u64);
+        eprintln!("qm31 mul_by_m31: {}", u31ext_mul_u31::<QM31>().len());
+
+        let a = rng.gen::<F4>();
+        let b = rng.gen::<F>();
+
+        let c = a * F4::new(
+            Complex::<p3_mersenne_31::Mersenne31>::new(b, F::zero()),
+            Complex::<p3_mersenne_31::Mersenne31>::zero(),
+        );
+
+        let a: &[Complex<p3_mersenne_31::Mersenne31>] = a.as_base_slice();
+        let c: &[Complex<p3_mersenne_31::Mersenne31>] = c.as_base_slice();
+
+        let script = script! {
+            { a[1].imag().as_canonical_u32() }
+            { a[1].real().as_canonical_u32() }
+            { a[0].imag().as_canonical_u32() }
+            { a[0].real().as_canonical_u32() }
+            { b.as_canonical_u32() }
+            { mul_script.clone() }
+            { c[1].imag().as_canonical_u32() }
+            { c[1].real().as_canonical_u32() }
+            { c[0].imag().as_canonical_u32() }
+            { c[0].real().as_canonical_u32() }
+            { u31ext_equalverify::<QM31>() }
+            OP_TRUE
+        };
+
+        let exec_result = execute_script(script);
+        println!("{:4}", exec_result.final_stack);
+        println!("{:?}", exec_result.error);
+        assert!(exec_result.success);
     }
 }


### PR DESCRIPTION
This is useful in the STARK verifier where we do a few ibutterfly. 

It is important to note that the coefficient is an M31 not a full QM31. This PR provides an implementation that is faster than doing four M31 separately.